### PR TITLE
Ntrnl 444 add util to retrieve email from cola jwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@co-digital/logging": "^1.0.2",
-        "cookie-parser": "^1.4.6"
+        "cookie-parser": "^1.4.6",
+        "jwt-decode": "^4.0.0"
       },
       "devDependencies": {
         "@types/cookie-parser": "^1.4.6",
@@ -3919,6 +3920,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   ],
   "dependencies": {
     "@co-digital/logging": "^1.0.2",
-    "cookie-parser": "^1.4.6"
+    "cookie-parser": "^1.4.6",
+    "jwt-decode": "^4.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,12 @@ import {
     removeApplicationDataByID
 } from './utils/session';
 import { authentication as colaAuthenticationMiddleware } from './middleware/cola/authentication.middleware';
-import { getUnsignedCookie } from './utils/cookie';
+import { getUnsignedCookie, getUserEmailFromColaJwt } from './utils/cookie';
 
 export {
     colaAuthenticationMiddleware,
     getUnsignedCookie,
+    getUserEmailFromColaJwt,
     removeSessionData,
     getSessionData,
     setSessionData,

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,0 +1,20 @@
+export interface DecodedColaJwt {
+  sub?: string,
+  email_verified?: boolean,
+  'custom:lastLogin'?: string,
+  'custom:features'?: string,
+  iss?: string,
+  'cognito:username'?: string,
+  given_name?: string,
+  origin_jti?: string,
+  aud?: string,
+  event_id?: string,
+  token_use?: string,
+  'custom:phoneNumber'?: string,
+  auth_time?: number,
+  exp?: number,
+  iat?: number,
+  family_name?: string,
+  jti?: string,
+  email?: string
+}

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,4 +1,7 @@
+import { DecodedColaJwt } from '../model';
+
 import cookieParser from 'cookie-parser';
+import { jwtDecode } from 'jwt-decode';
 
 export const getCookieValue = (cookies: any, cookieName: string): string => {
     return cookies[cookieName];
@@ -10,4 +13,8 @@ export const getUnsignedCookie = (parsedCookie: string, cookieSecret: string): s
 
 export const validateUnsignedCookie = (unsignedCookie: string | false): boolean => {
     return !(!unsignedCookie || unsignedCookie === 'undefined');
+};
+
+export const getUserEmailFromColaJwt = (jwt: string): string | undefined => {
+    return jwtDecode<DecodedColaJwt>(jwt)?.email;
 };

--- a/test/unit/utils/cookie.spec.ts
+++ b/test/unit/utils/cookie.spec.ts
@@ -1,4 +1,5 @@
 jest.mock('cookie-parser');
+jest.mock('jwt-decode');
 
 import { jest, describe, expect, test, afterEach } from '@jest/globals';
 import cookieParser from 'cookie-parser';
@@ -6,14 +7,17 @@ import cookieParser from 'cookie-parser';
 import {
     getCookieValue,
     getUnsignedCookie,
+    getUserEmailFromColaJwt,
     validateUnsignedCookie
 } from '../../../src/utils/cookie';
 import {
     COOKIE_ID_NAME,
     COOKIE_PARSER_SECRET
 } from '../../../src/config';
+import { jwtDecode } from 'jwt-decode';
 
 const cookieParserSignedCookieMock = cookieParser.signedCookie as jest.Mock;
+const jwtDecodeMock = jwtDecode as jest.Mock;
 
 const mockCookie = (info: string) => {
     const cookies = {};
@@ -21,6 +25,11 @@ const mockCookie = (info: string) => {
     return cookies;
 };
 const mockCookieValue = '123oQCS75NUe4OVK78';
+
+const mockJwt = 'ey4590u82035577';
+const mockDecodedColaJwt = {
+    email: 'email@fake.com'
+};
 
 describe('Utils Cookies', () => {
 
@@ -52,6 +61,32 @@ describe('Utils Cookies', () => {
     test('Test function validateUnsignedCookie(), it should be true if correct cookie passed', () => {
         const isValidCookie = validateUnsignedCookie(mockCookieValue);
         expect(isValidCookie).toBeTruthy;
+    });
+
+    test('Test function getUserEmailFromColaJwt(), it should call jwtDecode with jwt passed in', () => {
+
+        getUserEmailFromColaJwt(mockJwt);
+
+        expect(jwtDecodeMock).toHaveBeenCalledTimes(1);
+        expect(jwtDecodeMock).toHaveBeenCalledWith(mockJwt);
+    });
+
+    test('Test function getUserEmailFromColaJwt(), it should return email property value from decoded JWT', () => {
+
+        jwtDecodeMock.mockReturnValue(mockDecodedColaJwt);
+
+        const email = getUserEmailFromColaJwt(mockJwt);
+
+        expect(email).toBe(mockDecodedColaJwt.email);
+    });
+
+    test('Test function getUserEmailFromColaJwt(), it should return undefined if email property is not present on decodedJWT', () => {
+
+        jwtDecodeMock.mockReturnValue({});
+
+        const email = getUserEmailFromColaJwt(mockJwt);
+
+        expect(email).toBe(undefined);
     });
 
 });


### PR DESCRIPTION
### JIRA link

[NTRNL-444](https://technologyprogramme.atlassian.net/browse/NTRNL-444?focusedCommentId=154386&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-154386)

### Description

Add util to retrieve email from COLA jwt. Example usage of this util:

```
import { getUserEmailFromColaJwt } from '@co-digital/login'

...
  const jwt = req.signedCookies[COOKIE_ID_NAME]; // COOKIE_ID_NAME comes from COLA
  const email = getUserEmailFromColaJwt(jwt);
  console.log(email);
...
```

### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added