### PR TITLE
Ntrnl 499 extract user email from cola jwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@co-digital/login",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@co-digital/login",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A login library for Node.JS applications in CO Digital.",
   "homepage": "https://github.com/cabinetoffice/node-login#README.md",
   "main": "./lib/index.js",

--- a/src/middleware/cola/authentication.middleware.ts
+++ b/src/middleware/cola/authentication.middleware.ts
@@ -8,6 +8,7 @@ import {
 import {
     getCookieValue,
     getUnsignedCookie,
+    getUserEmailFromColaJwt,
     validateUnsignedCookie
 } from '../../utils/cookie';
 
@@ -19,6 +20,8 @@ export const authentication = ( req: Request, res: Response, next: NextFunction 
         const unsignedCookie = getUnsignedCookie(cookieSignedValue, COOKIE_PARSER_SECRET);
 
         if (validateUnsignedCookie(unsignedCookie)) {
+            const userEmailAuth = getUserEmailFromColaJwt(unsignedCookie as string);
+            res.locals.userEmailAuth = userEmailAuth;
             log.debugRequest(req, `Successfully verified signature for ${COOKIE_ID_NAME}, cookie value: ${unsignedCookie}`);
         } else {
             log.errorRequest(req, `Failed to verify signature for ${COOKIE_ID_NAME}, cookie value: ${cookieSignedValue}, redirect to ${AUTH_SIGN_IN_URL}`);

--- a/test/unit/middleware/cola/authentication.middleware.spec.ts
+++ b/test/unit/middleware/cola/authentication.middleware.spec.ts
@@ -16,7 +16,8 @@ import { log } from '../../../../src/utils/logger';
 import {
     getCookieValue,
     getUnsignedCookie,
-    validateUnsignedCookie
+    validateUnsignedCookie,
+    getUserEmailFromColaJwt,
 } from '../../../../src/utils/cookie';
 import { cookieSignedValue, req } from '../../../mock/data.mock';
 
@@ -26,10 +27,12 @@ const logErrorRequestMock = log.errorRequest as jest.Mock;
 const getCookieValueMock = getCookieValue as jest.Mock;
 const getUnsignedCookieMock = getUnsignedCookie as jest.Mock;
 const validateUnsignedCookieMock = validateUnsignedCookie as jest.Mock;
+const getUserEmailFromColaJwtMock = getUserEmailFromColaJwt as jest.Mock;
 
 export const mockResponse = () => {
     const res = {} as Response;
     res.redirect = jest.fn() as any;
+    res.locals = {};
     return res;
 };
 
@@ -86,6 +89,21 @@ describe('Cola Authentication Middleware test suites', () => {
 
         expect(logErrorRequestMock).toHaveBeenCalledTimes(0);
         expect(res.redirect).toHaveBeenCalledTimes(0);
+    });
+
+    test('should attach userEmailAuth property to res.locals if validation is successful', () => {
+        const unsignedCookie = 'xyz.123';
+        const email = 'placeholder@fake.com';
+
+        getUnsignedCookieMock.mockReturnValueOnce(unsignedCookie);
+        validateUnsignedCookieMock.mockReturnValueOnce(true);
+        getUserEmailFromColaJwtMock.mockReturnValueOnce(email);
+
+        authentication(req, res, next);
+
+        expect(getUserEmailFromColaJwtMock).toHaveBeenCalledTimes(1);
+        expect(getUserEmailFromColaJwtMock).toHaveBeenCalledWith(unsignedCookie);
+        expect(res.locals.userEmailAuth).toBe(email);
     });
 
     test('should call next with error object if error is thrown', () => {


### PR DESCRIPTION
### JIRA link

[NTRNL-499](https://technologyprogramme.atlassian.net/jira/software/projects/NTRNL/boards/312?selectedIssue=NTRNL-499)

### Description

Extract `userEmail` from COLA JWT and attach to `res.locals` as `userEmailAuth` property. This makes the `userEmail` available for an application to use when using the COLA middleware. 

This change was tested by locally installing this library into the [GitHub Requests application](https://github.com/cabinetoffice/github-requests-app) and logging out the email in a controller:

```
// home.controller.ts

export const get = (req: Request, res: Response, next: NextFunction) => {
    try {
        const appData: ApplicationData = getSessionData(req.session);

        console.log('hello from home controller');
        console.log(res.locals.userEmailAuth);

        return res.render(config.HOME, {
            ...appData
        });
    } catch (err: any) {
        log.errorRequest(req, err.message);
        next(err);
    }
};
```
### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added